### PR TITLE
feat: add option to customize row selection and row collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This fork of ember-table is used by Lighthouse where the following changes have 
 
 | PR | Short Description |
 | --- | --- |
-| ... | Add ability to customise the row selection and row collapsing/expanding |
+| https://github.com/OTA-Insight/ember-table/pull/1/ | Add ability to customise the row selection and row collapsing/expanding |
 
 # Ember Table
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 ![npm version](https://img.shields.io/npm/v/ember-table)
 
+# Changes by Lighthouse
+
+This fork of ember-table is used by Lighthouse where the following changes have been made:
+
+| PR | Short Description |
+| --- | --- |
+| ... | Add ability to customise the row selection and row collapsing/expanding |
+
 # Ember Table
 
 An addon to support large data set and a number of features around table. Ember Table can

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -1,30 +1,38 @@
 {{#if this.isFirstColumn}}
   <div class="et-cell-container">
     {{#if this.canSelect}}
-      <span
-        class="et-toggle-select {{unless this.shouldShowCheckbox 'et-speech-only'}}"
-        data-test-select-row-container
-      >
-        <EmberTableSimpleCheckbox
-          @checked={{this.rowMeta.isGroupSelected}}
-          @onClick={{action "onSelectionToggled"}}
-          @ariaLabel="Select row"
-          @dataTestSelectRow={{this.isTesting}}
-        />
-        <span></span>
-      </span>
+      {{#if (has-block "select")}}
+        {{yield this.rowMeta (action "onSelectionToggled") to="select"}}
+      {{else}}
+        <span
+          class="et-toggle-select {{unless this.shouldShowCheckbox 'et-speech-only'}}"
+          data-test-select-row-container
+        >
+          <EmberTableSimpleCheckbox
+            @checked={{this.rowMeta.isGroupSelected}}
+            @onClick={{action "onSelectionToggled"}}
+            @ariaLabel="Select row"
+            @dataTestSelectRow={{this.isTesting}}
+          />
+          <span></span>
+        </span>
+      {{/if}}
     {{/if}}
 
     {{#if this.canCollapse}}
-      <span class="et-toggle-collapse et-depth-indent {{this.depthClass}}">
-        <EmberTableSimpleCheckbox
-          @checked={{this.rowMeta.isCollapsed}}
-          @onChange={{action "onCollapseToggled"}}
-          @ariaLabel="Collapse row"
-          @dataTestCollapseRow={{this.isTesting}}
-        />
-        <span></span>
-      </span>
+      {{#if (has-block "collapse")}}
+        {{yield this.rowMeta (action "onCollapseToggled") to="collapse"}}
+      {{else}}
+        <span class="et-toggle-collapse et-depth-indent {{this.depthClass}}">
+          <EmberTableSimpleCheckbox
+            @checked={{this.rowMeta.isCollapsed}}
+            @onChange={{action "onCollapseToggled"}}
+            @ariaLabel="Collapse row"
+            @dataTestCollapseRow={{this.isTesting}}
+          />
+          <span></span>
+        </span>
+      {{/if}}
     {{else}}
       <div class="et-depth-indent et-depth-placeholder {{this.depthClass}}"></div>
     {{/if}}

--- a/types/components/ember-td/component.d.ts
+++ b/types/components/ember-td/component.d.ts
@@ -23,6 +23,14 @@ export interface EmberTdSignature<RowType, ColumnType> {
       columnMeta: unknown,
       rowMeta: TableRowMeta,
     ];
+    select?: [
+      rowMeta: TableRowMeta,
+      onSelectionToggled: () => void,
+    ];
+    collapse?: [
+      rowMeta: TableRowMeta,
+      onCollapseToggled: () => void,
+    ];
   };
 }
 


### PR DESCRIPTION
With the current version of ember-table, you can only customize the row selection and row collapse visualisation through CSS overrides of the input type="checkbox" element and its empty sibling span element.

This PR aims to unlock a way of customizing the row selection and row collapse visualisation as a whole, allowing people to use their own (design system) components instead of using CSS.

PR to `Addepar/ember-table`: https://github.com/Addepar/ember-table/pull/1107