### PR TITLE
Root row indeterminate state

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This fork of ember-table is used by Lighthouse where the following changes have 
 | https://github.com/OTA-Insight/ember-table/pull/1/ | Add ability to customise the row selection and row collapsing/expanding   |
 | https://github.com/OTA-Insight/ember-table/pull/3/ | Change the order of the collapse/expand button and the selection checkbox |
 | https://github.com/OTA-Insight/ember-table/pull/4/ | Fix min and maxWidth not being respected when gte-container-slack is used |
+| https://github.com/OTA-Insight/ember-table/pull/5/ | Add indeterminate state to root rows when a child is selected             |
 
 # Ember Table
 
@@ -42,6 +43,7 @@ Newer versions are used to support Ember >= 3.28
 - Handles transient state at cell level.
 - Single, multiple row selection.
 - Table grouping.
+- Root row indeterminate state
 
 ## Documentation
 

--- a/addon-test-support/pages/-private/ember-table-body.js
+++ b/addon-test-support/pages/-private/ember-table-body.js
@@ -75,6 +75,7 @@ export default PageObject.extend({
     checkbox: {
       scope: '[data-test-select-row]',
       isChecked: property('checked'),
+      isIndeterminate: property('indeterminate'),
 
       async clickWith(options) {
         await click(findElement(this), options);
@@ -97,6 +98,8 @@ export default PageObject.extend({
     toggleCollapse: alias('collapse.click'),
 
     isSelected: hasClass('is-selected'),
+
+    isGroupIndeterminate: hasClass('is-group-indeterminate'),
 
     /**
       Helper function to click with options like the meta key and ctrl key set

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -83,6 +83,36 @@ export const TableRowMeta = EmberObject.extend({
     }
   ),
 
+  isGroupIndeterminate: computed(
+    '_tree.{selection.[],selectionMatchFunction,selectingChildrenSelectsParent}',
+    function() {
+      let rowValue = get(this, '_rowValue');
+      let selection = get(this, '_tree.selection');
+      let selectionMatchFunction = get(this, '_tree.selectionMatchFunction');
+      let selectingChildrenSelectsParent = get(this, '_tree.selectingChildrenSelectsParent');
+
+      if (!rowValue.children || !isArray(rowValue.children)) {
+        return false;
+      }
+
+      if (!selection || !isArray(selection)) {
+        return false;
+      }
+
+      if (!selectingChildrenSelectsParent) {
+        return false;
+      }
+
+      if (selectionMatchFunction) {
+        return rowValue.children.some(child =>
+          selection.some(item => selectionMatchFunction(item, child))
+        );
+      }
+
+      return rowValue.children.some(child => selection.includes(child));
+    }
+  ),
+
   canCollapse: computed(
     '_tree.{enableTree,enableCollapse}',
     '_rowValue.{children.[],disableCollapse}',

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -103,13 +103,15 @@ export const TableRowMeta = EmberObject.extend({
         return false;
       }
 
-      if (selectionMatchFunction) {
-        return rowValue.children.some(child =>
-          selection.some(item => selectionMatchFunction(item, child))
-        );
-      }
+      let matchFunction = (selection, item) => {
+        if (selectionMatchFunction) {
+          return selection.some(selectionItem => selectionMatchFunction(selectionItem, item));
+        }
 
-      return rowValue.children.some(child => selection.includes(child));
+        return selection.includes(item);
+      };
+
+      return rowValue.children.some(child => matchFunction(selection, child));
     }
   ),
 

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -103,7 +103,7 @@ export const TableRowMeta = EmberObject.extend({
         return false;
       }
 
-      let matchFunction = (selection, item) => {
+      let isItemSelected = (selection, item) => {
         if (selectionMatchFunction) {
           return selection.some(selectionItem => selectionMatchFunction(selectionItem, item));
         }
@@ -111,7 +111,12 @@ export const TableRowMeta = EmberObject.extend({
         return selection.includes(item);
       };
 
-      return rowValue.children.some(child => matchFunction(selection, child));
+      return rowValue.children.some(child => {
+        let childRowMeta = get(this, '_tree.rowMetaCache').get(child);
+        let isChildIndeterminate = childRowMeta.isGroupIndeterminate;
+
+        return isItemSelected(selection, child) || isChildIndeterminate;
+      });
     }
   ),
 

--- a/addon/-private/collapse-tree.js
+++ b/addon/-private/collapse-tree.js
@@ -113,7 +113,7 @@ export const TableRowMeta = EmberObject.extend({
 
       return rowValue.children.some(child => {
         let childRowMeta = get(this, '_tree.rowMetaCache').get(child);
-        let isChildIndeterminate = childRowMeta.isGroupIndeterminate;
+        let isChildIndeterminate = !!childRowMeta?.isGroupIndeterminate;
 
         return isItemSelected(selection, child) || isChildIndeterminate;
       });

--- a/addon/components/ember-td/template.hbs
+++ b/addon/components/ember-td/template.hbs
@@ -28,6 +28,7 @@
         >
           <EmberTableSimpleCheckbox
             @checked={{this.rowMeta.isGroupSelected}}
+            @indeterminate={{this.rowMeta.isGroupIndeterminate}}
             @onClick={{action "onSelectionToggled"}}
             @ariaLabel="Select row"
             @dataTestSelectRow={{this.isTesting}}

--- a/addon/components/ember-tr/component.js
+++ b/addon/components/ember-tr/component.js
@@ -48,7 +48,7 @@ export default Component.extend({
   layout,
   tagName: 'tr',
   classNames: ['et-tr'],
-  classNameBindings: ['isSelected', 'isGroupSelected', 'isSelectable'],
+  classNameBindings: ['isSelected', 'isGroupSelected', 'isGroupIndeterminate', 'isSelectable'],
 
   /**
     The API object passed in by the table body, header, or footer
@@ -87,6 +87,8 @@ export default Component.extend({
   isSelected: readOnly('rowMeta.isSelected'),
 
   isGroupSelected: readOnly('rowMeta.isGroupSelected'),
+
+  isGroupIndeterminate: readOnly('rowMeta.isGroupIndeterminate'),
 
   isSelectable: computed('rowSelectionMode', function() {
     let rowSelectionMode = this.get('rowSelectionMode');

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -483,6 +483,31 @@ module('Integration | selection', () => {
         assert.ok(row.isSelected, 'the row is selected');
         assert.ok(!row.checkbox.isChecked, 'the row checkbox is checked');
       });
+
+      test('Selecting a child row causes parent checkbox to be indeterminate', async function(assert) {
+        await generateTable(this, { rowCount: 3, rowDepth: 2 });
+
+        let parentRow = table.rows.objectAt(0);
+        let childRow = table.rows.objectAt(1);
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(!parentRow.isGroupIndeterminate, 'parent row is not indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(!parentRow.checkbox.isIndeterminate, 'parent row checkbox is not indeterminate');
+
+        assert.ok(!childRow.isSelected, 'child row is not selected');
+
+        await childRow.checkbox.click();
+
+        assert.ok(childRow.isSelected, 'child row is selected');
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(parentRow.isGroupIndeterminate, 'parent row is indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(parentRow.checkbox.isIndeterminate, 'parent row checkbox is indeterminate');
+      });
     });
 
     componentModule('single', function() {
@@ -531,6 +556,31 @@ module('Integration | selection', () => {
         await generateTable(this, { checkboxSelectionMode: 'single' });
 
         await table.selectRow(0);
+      });
+
+      test('Selecting a child row causes parent checkbox to be indeterminate', async function(assert) {
+        await generateTable(this, { rowCount: 3, rowDepth: 2, checkboxSelectionMode: 'single' });
+
+        let parentRow = table.rows.objectAt(0);
+        let childRow = table.rows.objectAt(1);
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(!parentRow.isGroupIndeterminate, 'parent row is not indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(!parentRow.checkbox.isIndeterminate, 'parent row checkbox is not indeterminate');
+
+        assert.ok(!childRow.isSelected, 'child row is not selected');
+
+        await childRow.checkbox.click();
+
+        assert.ok(childRow.isSelected, 'child row is selected');
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(parentRow.isGroupIndeterminate, 'parent row is indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(parentRow.checkbox.isIndeterminate, 'parent row checkbox is indeterminate');
       });
     });
 

--- a/tests/integration/components/selection-test.js
+++ b/tests/integration/components/selection-test.js
@@ -508,6 +508,44 @@ module('Integration | selection', () => {
         assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
         assert.ok(parentRow.checkbox.isIndeterminate, 'parent row checkbox is indeterminate');
       });
+
+      test('Selecting a child of a child row causes the parent checkbox to be indeterminate', async function(assert) {
+        await generateTable(this, { rowCount: 5, rowDepth: 3 });
+
+        let parentRow = table.rows.objectAt(0);
+        let childRow = table.rows.objectAt(1);
+        let grandchildRow = table.rows.objectAt(2);
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(!parentRow.isGroupIndeterminate, 'parent row is not indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(!parentRow.checkbox.isIndeterminate, 'parent row checkbox is not indeterminate');
+
+        assert.ok(!childRow.isSelected, 'child row is not selected');
+        assert.ok(!childRow.isGroupIndeterminate, 'child row is not indeterminate');
+
+        assert.ok(!childRow.checkbox.isChecked, 'child row checkbox is not checked');
+        assert.ok(!childRow.checkbox.isIndeterminate, 'child row checkbox is not indeterminate');
+
+        assert.ok(!grandchildRow.isSelected, 'grandchild row is not selected');
+
+        await grandchildRow.checkbox.click();
+
+        assert.ok(grandchildRow.isSelected, 'grandchild row is selected');
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(parentRow.isGroupIndeterminate, 'parent row is indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(parentRow.checkbox.isIndeterminate, 'parent row checkbox is indeterminate');
+
+        assert.ok(!childRow.isSelected, 'child row is not selected');
+        assert.ok(childRow.isGroupIndeterminate, 'child row is indeterminate');
+
+        assert.ok(!childRow.checkbox.isChecked, 'child row checkbox is not checked');
+        assert.ok(childRow.checkbox.isIndeterminate, 'child row checkbox is indeterminate');
+      });
     });
 
     componentModule('single', function() {
@@ -581,6 +619,44 @@ module('Integration | selection', () => {
 
         assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
         assert.ok(parentRow.checkbox.isIndeterminate, 'parent row checkbox is indeterminate');
+      });
+
+      test('Selecting a child of a child row causes the parent checkbox to be indeterminate', async function(assert) {
+        await generateTable(this, { rowCount: 5, rowDepth: 3, checkboxSelectionMode: 'single' });
+
+        let parentRow = table.rows.objectAt(0);
+        let childRow = table.rows.objectAt(1);
+        let grandchildRow = table.rows.objectAt(2);
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(!parentRow.isGroupIndeterminate, 'parent row is not indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(!parentRow.checkbox.isIndeterminate, 'parent row checkbox is not indeterminate');
+
+        assert.ok(!childRow.isSelected, 'child row is not selected');
+        assert.ok(!childRow.isGroupIndeterminate, 'child row is not indeterminate');
+
+        assert.ok(!childRow.checkbox.isChecked, 'child row checkbox is not checked');
+        assert.ok(!childRow.checkbox.isIndeterminate, 'child row checkbox is not indeterminate');
+
+        assert.ok(!grandchildRow.isSelected, 'grandchild row is not selected');
+
+        await grandchildRow.checkbox.click();
+
+        assert.ok(grandchildRow.isSelected, 'grandchild row is selected');
+
+        assert.ok(!parentRow.isSelected, 'parent row is not selected');
+        assert.ok(parentRow.isGroupIndeterminate, 'parent row is indeterminate');
+
+        assert.ok(!parentRow.checkbox.isChecked, 'parent row checkbox is not checked');
+        assert.ok(parentRow.checkbox.isIndeterminate, 'parent row checkbox is indeterminate');
+
+        assert.ok(!childRow.isSelected, 'child row is not selected');
+        assert.ok(childRow.isGroupIndeterminate, 'child row is indeterminate');
+
+        assert.ok(!childRow.checkbox.isChecked, 'child row checkbox is not checked');
+        assert.ok(childRow.checkbox.isIndeterminate, 'child row checkbox is indeterminate');
       });
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,7 @@ export interface TableRowMeta {
   isCollapsed: boolean;
   isSelected: boolean;
   isGroupSelected: boolean;
+  isGroupIndeterminate: boolean;
   canCollapse: boolean;
   depth: number;
   first: unknown | null;


### PR DESCRIPTION
When working with nested checkboxes, 
when selecting a child checkbox - the parent checkbox should get an indeterminate state.

This MR adds this indeterminate behaviour.